### PR TITLE
Fix #1: Pridėti VideoBlock prie užduočių schemų

### DIFF
--- a/backend/tasks/schemas.py
+++ b/backend/tasks/schemas.py
@@ -101,6 +101,23 @@ class AudioBlock(BaseModel):
     duration_seconds: int | None = None
 
 
+class VideoBlock(BaseModel):
+    """Video content — AI-generated videos, news clips, social media videos.
+
+    Accessibility: alt_text is required (Framework Principle 14).
+    transcript provides text alternative for deaf/hard-of-hearing students.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    type: Literal["video"] = "video"
+    src: str
+    alt_text: str
+    transcript: str | None = None
+    duration_seconds: int | None = None
+
+
 class VideoTranscriptBlock(BaseModel):
     """Video transcript — full text of a video with optional source context."""
 
@@ -205,6 +222,7 @@ KNOWN_BLOCK_TYPES: dict[str, type[BaseModel]] = {
     "text": TextBlock,
     "image": ImageBlock,
     "audio": AudioBlock,
+    "video": VideoBlock,
     "video_transcript": VideoTranscriptBlock,
     "meme": MemeBlock,
     "chat_message": ChatMessageBlock,
@@ -264,6 +282,7 @@ PresentationBlock = Annotated[
         TextBlock,
         ImageBlock,
         AudioBlock,
+        VideoBlock,
         VideoTranscriptBlock,
         MemeBlock,
         ChatMessageBlock,

--- a/backend/tests/test_cartridge_integration.py
+++ b/backend/tests/test_cartridge_integration.py
@@ -30,11 +30,73 @@ from backend.tasks.schemas import (
     SearchResultBlock,
     SocialPostBlock,
     TaskCartridge,
+    VideoBlock,
 )
 
 # ---------------------------------------------------------------------------
 # Skeleton task IDs (Phase 5b)
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# VideoBlock schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestVideoBlockSchema:
+    """Verifies that VideoBlock validates correctly as a PresentationBlock."""
+
+    def test_video_block_loads_correctly(self) -> None:
+        """A cassette with a VideoBlock validates without errors."""
+        from backend.tasks.schemas import PresentationBlock
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(PresentationBlock)
+        block = adapter.validate_python({
+            "id": "v1",
+            "type": "video",
+            "src": "https://example.com/video.mp4",
+            "alt_text": "A news clip showing a protest",
+        })
+        assert isinstance(block, VideoBlock)
+        assert block.id == "v1"
+        assert block.type == "video"
+        assert block.src == "https://example.com/video.mp4"
+        assert block.alt_text == "A news clip showing a protest"
+        assert block.transcript is None
+        assert block.duration_seconds is None
+
+    def test_video_block_with_optional_fields(self) -> None:
+        """VideoBlock accepts optional transcript and duration_seconds."""
+        from backend.tasks.schemas import PresentationBlock
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(PresentationBlock)
+        block = adapter.validate_python({
+            "id": "v2",
+            "type": "video",
+            "src": "https://example.com/clip.mp4",
+            "alt_text": "AI-generated video of a politician",
+            "transcript": "Hello, I am a politician.",
+            "duration_seconds": 42,
+        })
+        assert isinstance(block, VideoBlock)
+        assert block.transcript == "Hello, I am a politician."
+        assert block.duration_seconds == 42
+
+    def test_video_block_alt_text_required(self) -> None:
+        """VideoBlock raises ValidationError when alt_text is missing."""
+        import pytest
+        from pydantic import TypeAdapter, ValidationError
+        from backend.tasks.schemas import PresentationBlock
+
+        adapter = TypeAdapter(PresentationBlock)
+        with pytest.raises(ValidationError):
+            adapter.validate_python({
+                "id": "v3",
+                "type": "video",
+                "src": "https://example.com/clip.mp4",
+            })
+
 
 SKELETON_IDS = [
     "task-cherry-pick-001",


### PR DESCRIPTION
## Summary

Add VideoBlock class to backend/tasks/schemas.py following the same pattern as ImageBlock, register it in KNOWN_BLOCK_TYPES, and add a test to verify it loads correctly.

## Approach

1. In backend/tasks/schemas.py, add a VideoBlock class after ImageBlock (or near it) with fields: id, type (Literal['video']), src, alt_text (required), transcript (optional), duration_seconds (optional), and model_config = ConfigDict(frozen=True). 2. Register 'video' -> VideoBlock in the KNOWN_BLOCK_TYPES dictionary. 3. In the test file (test_cartridge_integration.py or the schema test file), add a test that constructs a cassette/task with a VideoBlock and verifies it loads/validates correctly.

## Files Changed

- `backend/tasks/schemas.py`
- `backend/tests/test_cartridge_integration.py`

## Related Issue

Fixes #1

## Testing

No tests were added with this change. Happy to add them if needed.
